### PR TITLE
Add signal path resolution for active workflows

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,5 @@
+# Workflows
+
+## Aktive Geräte anzeigen
+
+Nach dem Aktivieren eines Workflows ermittelt `resolveSignalPath` alle beteiligten Geräte. Die Funktion geht die aktiven Verbindungen vom Ziel „L6 Master“ rückwärts durch und sammelt dabei die `deviceRef` der Quellen. Anschließend wird die Liste der Geräte im Element `#active-device-list` angezeigt.

--- a/index.html
+++ b/index.html
@@ -84,6 +84,12 @@ pre{background:#0b0f17;color:#e6edf6;border:1px solid #1f2635;padding:10px;borde
         </div>
       </section>
 
+      <!-- Aktive Geräte -->
+      <section class="card">
+        <div class="hd"><h2>Aktive Geräte</h2></div>
+        <div class="bd"><ul id="active-device-list"></ul></div>
+      </section>
+
       <!-- Apply-Engine Ausgabe -->
       <section class="card">
         <div class="hd"><h2>Output</h2><span class="pill">Apply JSON2</span></div>
@@ -92,6 +98,7 @@ pre{background:#0b0f17;color:#e6edf6;border:1px solid #1f2635;padding:10px;borde
     </main>
   </div>
 
+<script src="scripts/workflow-loader.js"></script>
 <script>
 let manifest = null;          // geladene Manifest v1.3
 const files = {};             // filename -> text (Zieltexte)

--- a/scripts/workflow-loader.js
+++ b/scripts/workflow-loader.js
@@ -1,0 +1,50 @@
+// scripts/workflow-loader.js
+// Reagiert auf aktivierte Workflows und zeigt beteiligte Geräte an.
+
+window.WorkflowLoader = (function(){
+  function resolveSignalPath(activeConnections = [], activeDevices = [], target = "L6 Master") {
+    const visited = new Set();
+    const path = [];
+
+    function walk(current){
+      for (const c of activeConnections){
+        const to = c.toDeviceRef || c.to;
+        if (to === current){
+          const from = c.fromDeviceRef || c.from;
+          if (!visited.has(from)){
+            visited.add(from);
+            path.push(from);
+            walk(from);
+          }
+        }
+      }
+    }
+
+    walk(target);
+
+    return path.map(ref => {
+      const dev = (activeDevices||[]).find(d => d.deviceRef === ref || d.ref === ref || d.id === ref);
+      return dev ? (dev.label || dev.name || dev.deviceRef || dev.id) : ref;
+    });
+  }
+
+  function renderDeviceList(list){
+    const el = document.getElementById('active-device-list');
+    if (!el) return;
+    el.innerHTML = '';
+    list.forEach(name => {
+      const li = document.createElement('li');
+      li.textContent = name;
+      el.appendChild(li);
+    });
+  }
+
+  document.addEventListener('workflowActivated', ev => {
+    const {activeConnections = [], activeDevices = [], target = "L6 Master"} = ev.detail || {};
+    const devices = resolveSignalPath(activeConnections, activeDevices, target);
+    renderDeviceList(devices);
+  });
+
+  return { resolveSignalPath };
+})();
+


### PR DESCRIPTION
## Summary
- show active devices when a workflow becomes active
- compute signal path from target via `resolveSignalPath`
- document active device display in workflow docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b968c0769c8324979a213c8ebcbac2