### PR TITLE
Use globalThis for JSON handlers and tests

### DIFF
--- a/__tests__/json1-handler.test.js
+++ b/__tests__/json1-handler.test.js
@@ -1,4 +1,4 @@
-// Lädt die Browser-Variante, registriert window.JSON1
+// Lädt die Browser-Variante, registriert globalThis.JSON1
 require('../scripts/json1-handler');
 
 describe('JSON1 handler (browser helpers)', () => {
@@ -17,11 +17,11 @@ describe('JSON1 handler (browser helpers)', () => {
     global.URL.revokeObjectURL = jest.fn();
 
     // <a> mit klickbarem Link mocken
-    document.createElement = jest.fn(() => ({ click: jest.fn() }));
+    globalThis.document = { createElement: jest.fn(() => ({ click: jest.fn() })) };
   });
 
   test('load() lädt Kommentare via fetch', async () => {
-    const data = await window.JSON1.load('imports/Struktur_JSON1.json');
+    const data = await globalThis.JSON1.load('imports/Struktur_JSON1.json');
     expect(fetch).toHaveBeenCalled();
     expect(Array.isArray(data)).toBe(true);
     expect(data).toHaveLength(2);
@@ -32,19 +32,19 @@ describe('JSON1 handler (browser helpers)', () => {
       { chapter_id: '100', cid: '1' },
       { chapter_id: '200', cid: '2' }
     ];
-    const res = window.JSON1.filterByChapter(list, '100');
+    const res = globalThis.JSON1.filterByChapter(list, '100');
     expect(res).toEqual([{ chapter_id: '100', cid: '1' }]);
   });
 
   test('markDone() setzt status=done', () => {
     const list = [{ chapter_id: '100', cid: '1', status: 'todo' }];
-    const out = window.JSON1.markDone(list, '1');
+    const out = globalThis.JSON1.markDone(list, '1');
     expect(out[0].status).toBe('done');
   });
 
   test('exportFile() erzeugt Download über <a> und Blob-URL', () => {
     const comments = [{ chapter_id: '100', cid: '1', status: 'done' }];
-    window.JSON1.exportFile(comments, 'Struktur_JSON1.json');
+    globalThis.JSON1.exportFile(comments, 'Struktur_JSON1.json');
 
     expect(URL.createObjectURL).toHaveBeenCalled();
     // a.click() wurde aufgerufen

--- a/__tests__/json2-handler.test.js
+++ b/__tests__/json2-handler.test.js
@@ -1,14 +1,14 @@
-require('../scripts/json2-handler'); // registriert window.JSON2H
+require('../scripts/json2-handler'); // registriert globalThis.JSON2H
 
 describe('JSON2 handler', () => {
   beforeEach(() => {
     global.URL.createObjectURL = jest.fn(() => 'blob://y');
     global.URL.revokeObjectURL = jest.fn();
-    document.createElement = jest.fn(() => ({ click: jest.fn() }));
+    globalThis.document = { createElement: jest.fn(() => ({ click: jest.fn() })) };
   });
 
   test('createAction() erstellt gültige Aktion', () => {
-    const a = window.JSON2H.createAction(200, 201, 'replace', 'cid-201', 'Text');
+    const a = globalThis.JSON2H.createAction(200, 201, 'replace', 'cid-201', 'Text');
     expect(a).toEqual({
       chapter_id: '200',
       cid: '201',
@@ -19,13 +19,13 @@ describe('JSON2 handler', () => {
   });
 
   test('build() kapselt Aktionen in {actions}', () => {
-    const list = [window.JSON2H.createAction(1, 1, 'replace', '1', '')];
-    expect(window.JSON2H.build(list)).toEqual({ actions: list });
+    const list = [globalThis.JSON2H.createAction(1, 1, 'replace', '1', '')];
+    expect(globalThis.JSON2H.build(list)).toEqual({ actions: list });
   });
 
   test('exportFile() triggert Datei-Download', () => {
     const json2 = { actions: [] };
-    window.JSON2H.exportFile(json2, 'Struktur_JSON2.json');
+    globalThis.JSON2H.exportFile(json2, 'Struktur_JSON2.json');
 
     expect(URL.createObjectURL).toHaveBeenCalled();
     const a = document.createElement.mock.results[0].value;

--- a/scripts/json1-handler.js
+++ b/scripts/json1-handler.js
@@ -1,7 +1,7 @@
 // scripts/json1-handler.js
-// Klassische <script>-Variante (legt Funktionen unter window.JSON1 ab)
+// Klassische <script>-Variante (legt Funktionen unter globalThis.JSON1 ab)
 
-window.JSON1 = (function(){
+globalThis.JSON1 = (function(){
   async function load(path = "imports/Struktur_JSON1.json") {
     const r = await fetch(path);
     if (!r.ok) throw new Error(`Konnte ${path} nicht laden (${r.status})`);

--- a/scripts/json2-handler.js
+++ b/scripts/json2-handler.js
@@ -1,7 +1,7 @@
 // scripts/json2-handler.js
-// Klassische <script>-Variante (legt Funktionen unter window.JSON2H ab)
+// Klassische <script>-Variante (legt Funktionen unter globalThis.JSON2H ab)
 
-window.JSON2H = (function(){
+globalThis.JSON2H = (function(){
   function createAction(chapterId, cid, type, id, contentMd) {
     return {
       chapter_id: String(chapterId),


### PR DESCRIPTION
## Summary
- Replace `window` with `globalThis` in browser helper scripts
- Adjust tests to use `globalThis` and stub `document` before mocking `createElement`
- Run Jest tests to confirm no `window` reference errors

## Testing
- `npm test`
- `npm run lint` *(fails: 'require' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7d7e4d0083249db711fb0bca901a