### PR TITLE
Add explicit anchors to markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+<a id="readme-tiagemusic-geraetesetup"></a>
 # 📘 README – TiageMusic Gerätesetup
 
+<a id="ueberblick"></a>
 ## Überblick
 Dieses Repository enthält die gesamte Dokumentation und Struktur für das **TiageMusic Gerätesetup**.  
 Alle Inhalte sind modular aufgebaut:  
@@ -10,6 +12,7 @@ das manifest ist deckungsgleich mit dem ##Inhalt dieser README datei.
 - **Schema (`modules/*.xsd`)** → strukturelle Validierung.  
 - **Modules (`.xlm`)** → settings.
 
+<a id="inhalt"></a>
 ## Inhalt
 - **chapters/** → Hauptinhalte als `.md`
   - 100_Einleitung.md
@@ -32,12 +35,14 @@ das manifest ist deckungsgleich mit dem ##Inhalt dieser README datei.
   - workflows.xml 
   - TiageMusic-setup.xml
 
+<a id="manifest"></a>
 ## Manifest
 Aktuelle Version: **v1.4**
 
  Gibt in der jeweilig aktuellsten Version strikt die Kapitelstruktur vor. Wenn keine MD datei mit dem 
  Titel innerhalb des Documents vorhanden ist wird diese md datei leer angelegt 
 
+<a id="workflow"></a>
 ## Workflow
 1. **Inhalt kommentieren**: comment.Json speichert alle kommentare bezogen auf Kapitel MD's gemäß Inhaltsstruktur.
 2. **Json1**: Exportieren der `comment.json` und weiterleiten an chatGPT

--- a/chapters/100_einleitung.md
+++ b/chapters/100_einleitung.md
@@ -1,3 +1,4 @@
+<a id="einleitung"></a>
 # Einleitung
 
 Version: 2025-09-03 04:25

--- a/chapters/200_geraeteuebersicht.md
+++ b/chapters/200_geraeteuebersicht.md
@@ -1,3 +1,4 @@
+<a id="geraeteuebersicht"></a>
 # Geräteübersicht
 
 Zoom L-6, Roland J-6, T-8, E-4, S-1, Sonicware Texture Lab, CME U61/U62.

--- a/chapters/300_Audio.md
+++ b/chapters/300_Audio.md
@@ -1,3 +1,4 @@
+<a id="audio"></a>
 # Audio
 
 Version: 2025-09-03 04:25

--- a/chapters/310_first_steps_audio_routing.md
+++ b/chapters/310_first_steps_audio_routing.md
@@ -1,3 +1,4 @@
+<a id="first-steps-audio-routing"></a>
 # First Steps – Audio & Routing
 
 - Audio-Interface Modi: Automatic, MultiTrack, Stereo Mix【133†source】

--- a/chapters/320_workflows_audio.md
+++ b/chapters/320_workflows_audio.md
@@ -1,3 +1,4 @@
+<a id="workflows-audio"></a>
 # Workflows Audio
 
 WF-A1: BR-80 Rear Line-In Summe

--- a/chapters/330_texture_lab.md
+++ b/chapters/330_texture_lab.md
@@ -1,3 +1,4 @@
+<a id="texture-lab-einsatz"></a>
 # Texture Lab Einsatz
 
 - Synth & FX Mode【136†source】

--- a/chapters/500_Midi.md
+++ b/chapters/500_Midi.md
@@ -1,3 +1,4 @@
+<a id="midi"></a>
 # Midi
 
 Version: 2025-09-03 04:25

--- a/chapters/510_first_steps_midi_setup.md
+++ b/chapters/510_first_steps_midi_setup.md
@@ -1,3 +1,4 @@
+<a id="first-steps-midi-setup"></a>
 # First Steps – MIDI & Setup
 
 - U61 = Master, Mapper, Clock【137†source】

--- a/chapters/520_workflows_midi.md
+++ b/chapters/520_workflows_midi.md
@@ -1,3 +1,4 @@
+<a id="workflows-midi"></a>
 # Workflows MIDI
 
 WF-M1: U61 Master + U62 Distribution

--- a/chapters/800_zusammenfassung.md
+++ b/chapters/800_zusammenfassung.md
@@ -1,3 +1,4 @@
+<a id="zusammenfassung"></a>
 # Zusammenfassung
 
 Audio über L-6 Scenes, MIDI mit U61/U62, Texture Lab als eigener Klangkörper.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,5 +1,7 @@
+<a id="workflows"></a>
 # Workflows
 
+<a id="aktive-geraete-anzeigen"></a>
 ## Aktive Geräte anzeigen
 
 Nach dem Aktivieren eines Workflows ermittelt `resolveSignalPath` alle beteiligten Geräte. Die Funktion geht die aktiven Verbindungen vom Ziel „L6 Master“ rückwärts durch und sammelt dabei die `deviceRef` der Quellen. Anschließend wird die Liste der Geräte im Element `#active-device-list` angezeigt.


### PR DESCRIPTION
## Summary
- add HTML anchor tags before README sections to provide stable IDs
- add matching anchors to each chapter markdown file and the docs workflow guide for consistent linking

## Testing
- npx --yes --package markdown-it-cli markdown-it README.md > /tmp/readme.html

------
https://chatgpt.com/codex/tasks/task_e_68c8e71271d483248ba5f89daf2940e4