### PR TITLE
Add CID anchors to chapter markdown files

### DIFF
--- a/chapters/100_einleitung.md
+++ b/chapters/100_einleitung.md
@@ -1,6 +1,8 @@
+<!-- cid:100:start -->
 <a id="einleitung"></a>
 # Einleitung
 
 Version: 2025-09-03 04:25
 
 Dieses Dokument bündelt Audio, MIDI und Workflows.
+<!-- cid:100:end -->

--- a/chapters/200_geraeteuebersicht.md
+++ b/chapters/200_geraeteuebersicht.md
@@ -1,4 +1,6 @@
+<!-- cid:200:start -->
 <a id="geraeteuebersicht"></a>
 # Geräteübersicht
 
 Zoom L-6, Roland J-6, T-8, E-4, S-1, Sonicware Texture Lab, CME U61/U62.
+<!-- cid:200:end -->

--- a/chapters/300_Audio.md
+++ b/chapters/300_Audio.md
@@ -1,6 +1,8 @@
+<!-- cid:300:start -->
 <a id="audio"></a>
 # Audio
 
 Version: 2025-09-03 04:25
 
 Dieses Dokument bündelt Audio
+<!-- cid:300:end -->

--- a/chapters/310_first_steps_audio_routing.md
+++ b/chapters/310_first_steps_audio_routing.md
@@ -1,5 +1,7 @@
+<!-- cid:310:start -->
 <a id="first-steps-audio-routing"></a>
 # First Steps – Audio & Routing
 
 - Audio-Interface Modi: Automatic, MultiTrack, Stereo Mix【133†source】
 - Scenes & Sound Pads【138†source】【141†source】
+<!-- cid:310:end -->

--- a/chapters/320_workflows_audio.md
+++ b/chapters/320_workflows_audio.md
@@ -1,6 +1,8 @@
+<!-- cid:320:start -->
 <a id="workflows-audio"></a>
 # Workflows Audio
 
 WF-A1: BR-80 Rear Line-In Summe
 WF-A2: Texture Lab Overdub
 WF-A3: E-4 Mic-In Quelle umschalten
+<!-- cid:320:end -->

--- a/chapters/330_texture_lab.md
+++ b/chapters/330_texture_lab.md
@@ -1,6 +1,8 @@
+<!-- cid:330:start -->
 <a id="texture-lab-einsatz"></a>
 # Texture Lab Einsatz
 
 - Synth & FX Mode【136†source】
 - MIDI-CC Chart【134†source】
 - Preset Patterns (Bank1)【142†source】
+<!-- cid:330:end -->

--- a/chapters/500_Midi.md
+++ b/chapters/500_Midi.md
@@ -1,6 +1,8 @@
+<!-- cid:500:start -->
 <a id="midi"></a>
 # Midi
 
 Version: 2025-09-03 04:25
 
 Dieses Dokument bündelt Midi
+<!-- cid:500:end -->

--- a/chapters/510_first_steps_midi_routing.md
+++ b/chapters/510_first_steps_midi_routing.md
@@ -1,6 +1,8 @@
+<!-- cid:510:start -->
 <a id="first-steps-midi-routing"></a>
 # First Steps – MIDI & Setup
 
 - U61 = Master, Mapper, Clock【137†source】
 - U62 = Preset-Empfänger/Distributor【135†source】
 - Merge 5 optional.
+<!-- cid:510:end -->

--- a/chapters/520_workflows_midi.md
+++ b/chapters/520_workflows_midi.md
@@ -1,6 +1,8 @@
+<!-- cid:520:start -->
 <a id="workflows-midi"></a>
 # Workflows MIDI
 
 WF-M1: U61 Master + U62 Distribution
 WF-M2: TL Solo via J-6
 WF-M3: Drum Solo (T-8 aktiv)
+<!-- cid:520:end -->

--- a/chapters/800_zusammenfassung.md
+++ b/chapters/800_zusammenfassung.md
@@ -1,4 +1,6 @@
+<!-- cid:800:start -->
 <a id="zusammenfassung"></a>
 # Zusammenfassung
 
 Audio über L-6 Scenes, MIDI mit U61/U62, Texture Lab als eigener Klangkörper.
+<!-- cid:800:end -->


### PR DESCRIPTION
## Summary
- wrap each chapter markdown file with cid start and end markers based on manifest IDs
- ensure all primary and subchapter files in chapters/ now have explicit replacement anchors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8f648c3008324bd8282863bdde4c8